### PR TITLE
Remove trailing comma

### DIFF
--- a/dumbplayer.py
+++ b/dumbplayer.py
@@ -17,7 +17,7 @@ class Player:
     #  their_spawn_point:
     #   An (x, y) tuple of where your opponent's chickens will hatch each turn
     def __init__(self, money_payout_rates, my_spawn_point, their_spawn_point):
-        self.money_payout_rates = money_payout_rates,
+        self.money_payout_rates = money_payout_rates
         self.my_spawn_point = my_spawn_point
         self.their_spawn_point = their_spawn_point
 


### PR DESCRIPTION
Remove trailing comma that leads to hard to spot bugs.
