### PR TITLE
BugFix map.py

### DIFF
--- a/map.py
+++ b/map.py
@@ -96,7 +96,7 @@ class Map:
         for (x, y), direction in p1_actions:
             quantity = int(p1_actions[((x, y), direction)])
             if direction not in actions.ALL_ACTIONS: continue
-            if self.p1_guys >= quantity:
+            if self.p1_guys[x][y] >= quantity:
                 new_x, new_y = actions.next_pos((x, y), direction)
                 if self.__is_on_board((new_x, new_y)):
                     new_p1_guys[new_x][new_y] += quantity
@@ -104,7 +104,7 @@ class Map:
         for (x, y), direction in p2_actions:
             quantity = int(p2_actions[((x, y), direction)])
             if direction not in actions.ALL_ACTIONS: continue
-            if self.p2_guys >= quantity:
+            if self.p2_guys[x][y] >= quantity:
                 new_x, new_y = actions.next_pos((x, y), direction)
                 if self.__is_on_board((new_x, new_y)):
                     new_p2_guys[new_x][new_y] += quantity


### PR DESCRIPTION
The previous version checks "self.p1_guys >= quantity" which is always True resulting in a situation where you can move more guys than you actually have. I think it should read:
"self.p1_guys[x][y] >= quantity"

You can check the bug in the original version by editing the orders line in randomplayer.py to
                orders[((x, y), random.choice(actions.ALL_ACTIONS))] = num_guys + 1
and run it. It creates a lot of funky output :)
